### PR TITLE
add: some writeups to the sequencing list

### DIFF
--- a/pages/sequencing-list.md
+++ b/pages/sequencing-list.md
@@ -18,7 +18,7 @@ Note: the maturity of these projects varies, and the documentation is usually no
   - [Espresso Sequencer Paper](https://github.com/EspressoSystems/HotShot/blob/main/docs/espresso-sequencer-paper.pdf)
 - [NodeKit SEQ](https://nodekit.gitbook.io/nodekit-documentation/)
 - [Radius](https://docs.theradius.xyz/)
-    - [Writeup on Raidus Sequencer](https://hackmd.io/@zeroknight/radius_decentralizing_rollup_sequencers)
+    - [Writeup on Radius Sequencer](https://hackmd.io/@zeroknight/radius_decentralizing_rollup_sequencers)
 
 ## Proposals
 
@@ -39,5 +39,5 @@ Note: the maturity of these projects varies, and the documentation is usually no
 
 ## Research Papers
 
-- [Buying Time: Latency Racing vs. Bidding for Transaction Ordering](https://arxiv.org/pdf/2306.02179.pdf)
+- [Buying Time: Latency Racing vs. Bidding for Transaction Ordering (Timeboost)](https://arxiv.org/pdf/2306.02179.pdf)
 - [SoK: Decentralized Sequencers for Rollups](https://arxiv.org/pdf/2310.03616.pdf)

--- a/pages/sequencing-list.md
+++ b/pages/sequencing-list.md
@@ -15,20 +15,29 @@ Note: the maturity of these projects varies, and the documentation is usually no
 - [Espresso](https://docs.espressosys.com)
   - [Writeup on the Espresso Sequencer](https://hackmd.io/@EspressoSystems/EspressoSequencer)
   - [Writeup on Shared Sequencing](https://hackmd.io/@EspressoSystems/SharedSequencing)
+  - [Espresso Sequencer Paper](https://github.com/EspressoSystems/HotShot/blob/main/docs/espresso-sequencer-paper.pdf)
 - [NodeKit SEQ](https://nodekit.gitbook.io/nodekit-documentation/)
 - [Radius](https://docs.theradius.xyz/)
+    - [Writeup on Raidus Sequencer](https://hackmd.io/@zeroknight/radius_decentralizing_rollup_sequencers)
 
 ## Proposals
 
 - [Sharing a Sequencer Set by Separating Execution from Aggregation](https://forum.celestia.org/t/sharing-a-sequencer-set-by-separating-execution-from-aggregation/702)
 - [Shared Validity Sequencing](https://www.umbraresearch.xyz/writings/shared-validity-sequencing)
-- [Aztek's Sequencing RFP](https://forum.aztec.network/t/request-for-proposals-decentralized-sequencer-selection/350/32)
+- [Aztek's Sequencing RFP](https://forum.aztec.network/t/request-for-proposals-decentralized-sequencer-selection/350) ([Medium Post](https://medium.com/aztec-protocol/aztec-sequencer-selection-finalists-122dbc6bb4))
   - [Fernet (Winner)](https://hackmd.io/0FwyoEjKSUiHQsmowXnJPw)
   - [B52 (Finalist)](https://hackmd.io/VIeqkDnMScG1B-DIVIyPLg)
   - [Whisk-y](https://forum.aztec.network/t/whisk-y-should-we-use-whisk-for-sequencer-selection/365)
   - [Cookie Jar](https://forum.aztec.network/t/proposal-sequencer-selection-cookie-jar/448)
-  - [Irish Coffee](https://forum.aztec.network/t/proposal-sequencer-selection-irish-coffee/483#vrf-specification-4)
+  - [Sequencer Schmequencer](https://discourse.aztec.network/t/proposal-sequencer-selection-sequencer-schmequencer/478)
+  - [Irish Coffee](https://forum.aztec.network/t/proposal-sequencer-selection-irish-coffee/483#vrf-specification-4) 
   - [Espresso Martini](https://forum.aztec.network/t/proposal-sequencer-selection-espresso-martini/486)
 - [Proof of Governance](https://dba.mirror.xyz/UTPfxWe65dYrUu_RJX-5VkAJypFRyw3AZh6m0dRXYZk) ([Video](https://www.youtube.com/watch?v=toPd1vgHjVE))
 - [Cross-ORU Contingent Blocks](https://prestwich.substack.com/p/contingency)
-- [Based Sequencing](https://www.youtube.com/watch?v=YqiCpLd8ecM&t=1964s)
+- [Based Rollups](https://ethresear.ch/t/based-rollups-superpowers-from-l1-sequencing/15016) ([Video](https://www.youtube.com/watch?v=YqiCpLd8ecM&t=1964s))
+
+
+## Research Papers
+
+- [Buying Time: Latency Racing vs. Bidding for Transaction Ordering](https://arxiv.org/pdf/2306.02179.pdf)
+- [SoK: Decentralized Sequencers for Rollups](https://arxiv.org/pdf/2310.03616.pdf)


### PR DESCRIPTION
Fixes #3 

Added :

- The Espresso Sequencer paper explaining HotShot Consensus and Tiramisu Data Availability
- Recent Radius sequencer writeup (by AJ Park from Raidus)
- Sequencer Schmequencer from Aztec RFP (@norswap was there a reason you left this?)


Made a research paper section and added :

- Buying Time: Latency Racing vs. Bidding for Transaction Ordering (by some people from offchain labs): This paper presents, TimeBoost, a practical transaction ordering policy for rollup sequencers that takes into
account both transaction timestamps and bids

- SoK: Decentralized Sequencers for Rollups (by matter labs): This paper presents a comprehensive exploration of decentralized sequencers in rollups, formulating their ideal properties and dissecting their core components

We can optionally add these papers to the proposal section or remove it, both are fine with me.


Also in the Aztec RFP there were 2 community contributions (rest were by aztec or espresso team) -
- [EigenLayer](https://discourse.aztec.network/t/proposal-leveraging-eigenlayer-and-reth-for-sequencer-selection/368)
- [Based rollup](https://discourse.aztec.network/t/proposal-based-rollup-simple-decentralized-tokenless-sequencerless-l2/479)

We can add these too. I didn't add because it didn't appeal to me much

I couldn't find any new projects (and proposals too except from aztec). Anyone knows of more please let me know.
